### PR TITLE
add privateuse blacklist (fix mac arrows keys)

### DIFF
--- a/Assets/Scripts/Seb/SebVis/UI/UI.cs
+++ b/Assets/Scripts/Seb/SebVis/UI/UI.cs
@@ -391,7 +391,7 @@ namespace Seb.Vis.UI
 					Draw.QuadOutline(ss.centre, ss.size, outlineWidth * scale, theme.focusBorderCol);
 					foreach (char c in InputHelper.InputStringThisFrame)
 					{
-						bool invalidChar = char.IsControl(c) || char.IsSurrogate(c) || char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.Format;
+						bool invalidChar = char.IsControl(c) || char.IsSurrogate(c) || char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.Format || char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.PrivateUse;
 						if (invalidChar) continue;
 						state.TryInsertText(c + "", validation);
 					}


### PR DESCRIPTION
with this, it looks like it works fine. i just added a blacklist type for privateuse, which seemed to fix it. very small fix, but it works!