### PR TITLE
Hozriontal name alignment

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/Scripts/Description/Types/ChipDescription.cs
+++ b/Assets/Scripts/Description/Types/ChipDescription.cs
@@ -1,5 +1,7 @@
 using System;
 using UnityEngine;
+using System.ComponentModel;
+
 
 namespace DLS.Description
 {
@@ -12,6 +14,8 @@ namespace DLS.Description
 		// ---- Data ----
 		public string Name;
 		public NameDisplayLocation NameLocation;
+		[DefaultValue(NameAlignment.Centre)]
+		public NameAlignment NameAlignment;
 		public ChipType ChipType;
 		public Vector2 Size;
 		public Color Colour;
@@ -32,5 +36,12 @@ namespace DLS.Description
 		Centre,
 		Top,
 		Hidden
+	}
+
+	public enum NameAlignment
+	{
+		Centre,
+		Right,
+		Left
 	}
 }

--- a/Assets/Scripts/Game/Elements/SubChipInstance.cs
+++ b/Assets/Scripts/Game/Elements/SubChipInstance.cs
@@ -38,8 +38,8 @@ namespace DLS.Game
 			ID = subChipDesc.ID;
 			Label = subChipDesc.Label;
 			IsBus = ChipTypeHelper.IsBusType(ChipType);
-			MultiLineName = CreateMultiLineName(description.Name);
-			MinSize = CalculateMinChipSize(description.InputPins, description.OutputPins, description.Name);
+			MultiLineName = CreateMultiLineName(description.Name, description.NameAlignment);
+			MinSize = CalculateMinChipSize(description.InputPins, description.OutputPins, description.Name, description.NameAlignment);
 
 			InputPins = CreatePinInstances(description.InputPins, true);
 			OutputPins = CreatePinInstances(description.OutputPins, false);
@@ -281,10 +281,10 @@ namespace DLS.Game
 			return Bounds2D.CreateFromCentreAndSize(Position + Vector2.right * offsetX, Size + padFinal);
 		}
 
-		public static Vector2 CalculateMinChipSize(PinDescription[] inputPins, PinDescription[] outputPins, string unformattedName)
+		public static Vector2 CalculateMinChipSize(PinDescription[] inputPins, PinDescription[] outputPins, string unformattedName, NameAlignment alignment)
 		{
 			float minHeightForPins = MinChipHeightForPins(inputPins, outputPins);
-			string multiLineName = CreateMultiLineName(unformattedName);
+			string multiLineName = CreateMultiLineName(unformattedName, alignment);
 			bool hasMultiLineName = multiLineName != unformattedName;
 			float minNameHeight = DrawSettings.GridSize * (hasMultiLineName ? 4 : 3);
 
@@ -309,7 +309,7 @@ namespace DLS.Game
 		}
 
 		// Split chip name into two lines (if contains a space character)
-		static string CreateMultiLineName(string name)
+		static string CreateMultiLineName(string name, NameAlignment alignment)
 		{
 			// If name is short, or contains no spaces, then just keep on single line
 			if (name.Length <= 6 || !name.Contains(' ')) return name;
@@ -333,7 +333,11 @@ namespace DLS.Game
 				}
 			}
 
+			return PadName(lines, alignment) ;
+		}
 
+		static string PadName(string[] lines, NameAlignment alignment)
+		{
 			// Pad lines with spaces to centre justify
 			string formatted = "";
 			int longestLine = lines.Max(l => l.Length);
@@ -342,7 +346,8 @@ namespace DLS.Game
 			{
 				string line = lines[i];
 				int numPadChars = longestLine - line.Length;
-				int numPadLeft = numPadChars / 2;
+				int numPadLeft = (alignment == NameAlignment.Centre) ? numPadChars / 2 :
+					(alignment == NameAlignment.Right) ? numPadChars : 0;
 				int numPadRight = numPadChars - numPadLeft;
 				line = line.PadLeft(line.Length + numPadLeft, ' ');
 				line = line.PadRight(line.Length + numPadRight, ' ');
@@ -359,6 +364,11 @@ namespace DLS.Game
 
 			return formatted;
 		}
+
+		public string GetUpdatedMultilineName()
+        {
+			return CreateMultiLineName(Description.Name, Description.NameAlignment);
+        }
 
 		public void FlipBus()
 		{

--- a/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
@@ -24,12 +24,20 @@ namespace DLS.Graphics
 			"Name: Hidden"
 		};
 
+		static readonly string[] nameAlignmentOptions =
+		{
+			"Center Aligned",
+			"Right Aligned",
+			"Left Aligned"
+		};
+
 		static SubChipInstance[] subChipsWithDisplays;
 		static string displayLabelString;
 
 		static readonly UIHandle ID_DisplaysScrollView = new("CustomizeMenu_DisplaysScroll");
 		static readonly UIHandle ID_ColourPicker = new("CustomizeMenu_ChipCol");
 		static readonly UIHandle ID_NameDisplayOptions = new("CustomizeMenu_NameDisplayOptions");
+		static readonly UIHandle ID_NameAlignmentOptions = new("CustomizeMenu_NameAlignmentOptions");
 		static readonly UI.ScrollViewDrawElementFunc drawDisplayScrollEntry = DrawDisplayScroll;
 
 		public static void OnMenuOpened()
@@ -64,6 +72,9 @@ namespace DLS.Graphics
 
 			int nameDisplayMode = UI.WheelSelector(ID_NameDisplayOptions, nameDisplayOptions, NextPos(), new Vector2(pw, 3), theme.OptionsWheel, Anchor.TopLeft);
 			ChipSaveMenu.ActiveCustomizeDescription.NameLocation = (NameDisplayLocation)nameDisplayMode;
+
+			int nameAlignmentMode = UI.WheelSelector(ID_NameAlignmentOptions, nameAlignmentOptions, NextPos(), new Vector2(pw, 3), theme.OptionsWheel, Anchor.TopLeft);
+			ChipSaveMenu.ActiveCustomizeDescription.NameAlignment = (NameAlignment)nameAlignmentMode;
 
 			Color newCol = UI.DrawColourPicker(ID_ColourPicker, NextPos(), pw, Anchor.TopLeft);
 			ChipSaveMenu.ActiveCustomizeDescription.Colour = newCol;

--- a/Assets/Scripts/Graphics/UI/Menus/ChipSaveMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipSaveMenu.cs
@@ -105,7 +105,7 @@ namespace DLS.Graphics
 					if (ActiveCustomizeDescription.Name != newName)
 					{
 						ActiveCustomizeDescription.Name = newName;
-						Vector2 minChipSize = SubChipInstance.CalculateMinChipSize(ActiveCustomizeDescription.InputPins, ActiveCustomizeDescription.OutputPins, newName);
+						Vector2 minChipSize = SubChipInstance.CalculateMinChipSize(ActiveCustomizeDescription.InputPins, ActiveCustomizeDescription.OutputPins, newName, NameAlignment.Centre);
 						Vector2 chipSizeNew = Vector2.Max(minChipSize, ActiveCustomizeDescription.Size);
 						ActiveCustomizeDescription.Size = chipSizeNew;
 					}

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -301,6 +301,14 @@ namespace DLS.Graphics
 				Anchor textAnchor = nameCentre ? Anchor.TextCentre : Anchor.CentreTop;
 				Vector2 textPos = nameCentre ? pos : pos + Vector2.up * (subchip.Size.y / 2 - GridSize / 2);
 
+				if (desc.NameAlignment != NameAlignment.Centre)
+				{
+					int mult = desc.NameAlignment == NameAlignment.Right ? 1 : -1;
+					TextRenderer.BoundingBox textBounds = Draw.CalculateTextBounds(displayName, FontBold, FontSizeChipName, textPos, textAnchor);
+					textPos.x += (pos.x + desc.Size.x / 2 - textBounds.BoundsMax.x) * mult;
+				}
+
+
 				// Draw background band behind text if placed at top (so it doesn't look out of place..)
 				if (desc.NameLocation == NameDisplayLocation.Top)
 				{

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -291,7 +291,7 @@ namespace DLS.Graphics
 			if (isButton || desc.NameLocation != NameDisplayLocation.Hidden)
 			{
 				// Display on single line if name fits comfortably, otherwise use 'formatted' version (split across multiple lines)
-				string displayName = isButton ? subchip.activationKeyString : subchip.MultiLineName;
+				string displayName = isButton ? subchip.activationKeyString : subchip.GetUpdatedMultilineName();
 				if (Draw.CalculateTextBoundsSize(subchip.Description.Name, FontSizeChipName, FontBold).x < subchip.Size.x - PinRadius * 2.5f)
 				{
 					displayName = subchip.Description.Name;

--- a/Assets/Scripts/SaveSystem/DescriptionCreator.cs
+++ b/Assets/Scripts/SaveSystem/DescriptionCreator.cs
@@ -24,7 +24,7 @@ namespace DLS.SaveSystem
 			PinDescription[] inputPins = OrderPins(chip.GetInputPins()).Select(CreatePinDescription).ToArray();
 			PinDescription[] outputPins = OrderPins(chip.GetOutputPins()).Select(CreatePinDescription).ToArray();
 			SubChipDescription[] subchips = chip.GetSubchips().Select(CreateSubChipDescription).ToArray();
-			Vector2 minChipsSize = SubChipInstance.CalculateMinChipSize(inputPins, outputPins, name);
+			Vector2 minChipsSize = SubChipInstance.CalculateMinChipSize(inputPins, outputPins, name, hasSavedDesc ? descOld.NameAlignment : NameAlignment.Centre);
 			size = Vector2.Max(minChipsSize, size);
 
 			// Store wire's current index in wire for convenient access
@@ -38,6 +38,7 @@ namespace DLS.SaveSystem
 			{
 				Name = name,
 				NameLocation = hasSavedDesc ? descOld.NameLocation : NameDisplayLocation.Centre,
+				NameAlignment = hasSavedDesc ? descOld.NameAlignment : NameAlignment.Centre,
 				Size = size,
 				Colour = col,
 

--- a/TestData/Projects/MainTest/Chips/7-SEGMENT DRIVER.json
+++ b/TestData/Projects/MainTest/Chips/7-SEGMENT DRIVER.json
@@ -1,8 +1,10 @@
 {
   "Name": "7-SEGMENT DRIVER",
   "NameLocation": 0,
+  "NameAlignment": 1,
+  "ChipType": 0,
   "Size": {
-    "x": 1.7,
+    "x": 2.23443,
     "y": 1.75
   },
   "Colour": {
@@ -809,6 +811,5 @@
       "Points":[{"x":0.0,"y":0.0},{"x":-2.625,"y":1.5},{"x":-2.625,"y":2.375},{"x":0.0,"y":0.0}]
     }
   ],
-  "Displays":[],
-  "ChipType": 0
+  "Displays":[]
 }

--- a/TestData/Projects/MainTest/ProjectDescription.json
+++ b/TestData/Projects/MainTest/ProjectDescription.json
@@ -1,9 +1,9 @@
 {
   "ProjectName": "MainTest",
-  "DLSVersion_LastSaved": "2.0.4",
+  "DLSVersion_LastSaved": "2.1.0",
   "DLSVersion_EarliestCompatible": "2.0.0",
   "CreationTime": "2025-03-14T18:23:30.404+01:00",
-  "LastSaveTime": "2025-04-15T00:40:26.898+02:00",
+  "LastSaveTime": "2025-04-16T00:14:12.658+02:00",
   "Prefs_MainPinNamesDisplayMode": 0,
   "Prefs_ChipPinNamesDisplayMode": 1,
   "Prefs_SimPaused": false,
@@ -109,7 +109,7 @@
     },
     {
       "Chips":["D-LATCH","FLIP-FLOP","OR-8","MEM-1","NOT-8","AND(8,1)","MUX-8","PC","BUF-8","ALU-8","DECODE-3","AND-3","CONTROL UNIT","TOGGLE","FLAGS","DISP-7","demo","7-SEGMENT DRIVER","DABBLE","LSB","LSHIFT-8","DOUBLE DABBLE","ALU","BUS BUFFER","MEM-256","REGISTER-8","XNOR","EQUALS-8","ADDER-4","DECODER-2","ADDER-8","ADDER","MEM-16","REGISTER-1","AND-8","RAM-256×8 (async)","ROM 256×16"],
-      "IsToggledOpen":false,
+      "IsToggledOpen":true,
       "Name":"KEEP"
     },
     {


### PR DESCRIPTION
Adds the customization option of aligning names horizontally (including padding), available directly under the name location option. 
It is fully compatible with save files that don't have the functionality.

![image](https://github.com/user-attachments/assets/4aac2c95-19bf-44a4-888b-55a7e93f13b5)
