### PR TITLE
fix: cancel order causing clipping on move cancel

### DIFF
--- a/Assets/Scripts/Game/Interaction/ChipInteractionController.cs
+++ b/Assets/Scripts/Game/Interaction/ChipInteractionController.cs
@@ -985,8 +985,8 @@ namespace DLS.Game
 
 		public void CancelEverything()
 		{
-			CancelPlacingItems();
 			CancelMovingSelectedItems();
+			CancelPlacingItems();
 			ClearSelection();
 			IsCreatingSelectionBox = false;
 			isPlacingNewElements = false;


### PR DESCRIPTION
Small UX issue causing chips to clip into each other when the cancel input was given (RMB/esc)
Seemed to be caused by the order in which `ChipInteractionController.CancelEverything()` called all the separate cancel methods.

Before:
![image](https://cdn.squiggles.dev/screenshots/Unity_cQ25k95Jba.gif)

After:
![image](https://cdn.squiggles.dev/screenshots/Unity_O98wAjORFX.gif)