### PR TITLE
feat: improve buzzer with a speaker-like display

### DIFF
--- a/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
@@ -68,7 +68,7 @@ namespace DLS.Game
 
 		static ChipDescription CreateBuzzer()
 		{
-			Color col = new(0, 0, 0);
+			Color col = new(0.1f, 0.1f, 0.1f);
 
 			PinDescription[] inputPins =
 			{
@@ -76,10 +76,20 @@ namespace DLS.Game
 				CreatePinDescription("VOLUME", 0, PinBitCount.Bit4),
 			};
 
-			float height = SubChipInstance.MinChipHeightForPins(inputPins, null);
-			Vector2 size = new(CalculateGridSnappedWidth(GridSize * 9), height);
+			Vector2 size = new(CalculateGridSnappedWidth(GridSize * 9), CalculateGridSnappedWidth(GridSize * 9));
+			float displayWidth = size.x - GridSize * 2;
 
-			return CreateBuiltinChipDescription(ChipType.Buzzer, size, col, inputPins, null, null);
+			DisplayDescription[] displays =
+			{
+				new()
+				{
+					Position = Vector2.zero,
+					Scale = displayWidth,
+					SubChipID = -1
+				}
+			};
+
+			return CreateBuiltinChipDescription(ChipType.Buzzer, size, col, inputPins, null, displays, NameDisplayLocation.Hidden);
 		}
 
 		static ChipDescription dev_CreateRAM_8()

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -459,35 +459,35 @@ namespace DLS.Graphics
 
 		public static Bounds2D DrawBuzzer(Vector2 centre, float scale, Color colour, SimChip simSource)
 		{
-			uint frequency = 0;
+			float frequency = 0;
 			uint amplitude = 0;
 
 			if (simSource != null)
 			{
-				frequency = simSource.InputPins[0].State;
+				frequency = simSource.InputPins[0].State > 27.5 ? SimAudio.CalculateFrequency(simSource.InputPins[0].State) : 27.5f;
 				amplitude = simSource.InputPins[1].State;
 			}
 
-			bool disconnectedOrMuted = simSource == null || amplitude == 0 || amplitude >= 16 || frequency >= 256;
+			bool disconnectedOrMuted = simSource == null || amplitude == 0 || simSource.InputPins[1].State >= 16 || simSource.InputPins[0].State >= 256;
 
 			float remappedAmplitude = Mathf.Lerp(0.25f, 1f, Mathf.InverseLerp(2.5f, 20, amplitude));
 
 			float oscillation = Mathf.Sin(Time.time * frequency);
 
 			float minLargeScale = 0.45f * scale;
-			float maxLargeScale = disconnectedOrMuted ? minLargeScale : Mathf.Lerp(minLargeScale, 0.5f, remappedAmplitude);
+			float maxLargeScale = Mathf.Lerp(minLargeScale, 0.5f * scale, remappedAmplitude);
 			float remappedLargeScale = Mathf.Lerp(minLargeScale, maxLargeScale, Mathf.InverseLerp(-1f, 1f, oscillation));
 
 			float minSmallScale = 0.075f * scale;
-			float maxSmallScale = disconnectedOrMuted ? minSmallScale : Mathf.Lerp(minSmallScale, 0.1f, remappedAmplitude);
+			float maxSmallScale = Mathf.Lerp(minSmallScale, 0.1f * scale, remappedAmplitude);
 			float remappedSmallScale = Mathf.Lerp(minSmallScale, maxSmallScale, Mathf.InverseLerp(1f, -1f, oscillation));
 
-			Vector2 finalLargeScale = remappedLargeScale * Vector2.one;
-			Vector2 finalSmallScale = remappedSmallScale * Vector2.one;
+			Vector2 finalLargeScale = disconnectedOrMuted ? minLargeScale * Vector2.one : remappedLargeScale * Vector2.one;
+			Vector2 finalSmallScale = disconnectedOrMuted ? minSmallScale * Vector2.one : remappedSmallScale * Vector2.one;
 
 			Draw.Ellipse(centre, finalLargeScale * 1.05f, GetChipOutlineCol(colour));
 			Draw.Ellipse(centre, finalLargeScale, ColHelper.Brighten(colour, 0.1f));
-			Draw.Ellipse(centre, finalSmallScale, colour);
+			Draw.Ellipse(centre, finalSmallScale, ColHelper.Darken(colour, 0.1f));
 			return Bounds2D.CreateFromCentreAndSize(centre, Vector2.one * scale);
 		}
 

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -440,6 +440,10 @@ namespace DLS.Graphics
 
 				bounds = DrawDisplay_LED(posWorld, scaleWorld, col);
 			}
+			else if (display.DisplayType == ChipType.Buzzer)
+			{
+				bounds = DrawBuzzer(posWorld, scaleWorld, sim);
+			}
 
 			display.LastDrawBounds = bounds;
 			return bounds;
@@ -447,6 +451,40 @@ namespace DLS.Graphics
 
 
 		public static Vector2 CalculateChipNameBounds(string name) => Draw.CalculateTextBoundsSize(name, FontSizeChipName, FontBold, ChipNameLineSpacing);
+
+		public static Bounds2D DrawBuzzer(Vector2 centre, float scale, SimChip simSource)
+		{
+			if (simSource == null)
+			{
+				return Bounds2D.CreateFromCentreAndSize(centre, Vector2.one * scale);
+			}
+
+			// Draw background
+			Draw.Quad(centre, 1.5f * scale * Vector2.one, new(0.1f, 0.1f, 0.1f));
+
+			uint frequency = simSource.InputPins[0].State;
+			uint amplitude = simSource.InputPins[1].State;
+
+			float remappedAmplitude = Mathf.Lerp(0.25f, 1f, Mathf.InverseLerp(2.5f, 20, amplitude));
+
+			float oscillation = Mathf.Sin(Time.time * frequency);
+
+			float minLargeScale = 0.45f * scale;
+			float maxLargeScale = amplitude == 0 ? minLargeScale : Mathf.Lerp(minLargeScale, 0.5f, remappedAmplitude);
+			float remappedLargeScale = Mathf.Lerp(minLargeScale, maxLargeScale, Mathf.InverseLerp(-1f, 1f, oscillation));
+
+			float minSmallScale = 0.075f * scale;
+			float maxSmallScale = amplitude == 0 ? minSmallScale : Mathf.Lerp(minSmallScale, 0.1f, remappedAmplitude);
+			float remappedSmallScale = Mathf.Lerp(minSmallScale, maxSmallScale, Mathf.InverseLerp(1f, -1f, oscillation));
+
+			Vector2 finalLargeScale = remappedLargeScale * Vector2.one;
+			Vector2 finalSmallScale = remappedSmallScale * Vector2.one;
+
+			Draw.Ellipse(centre, finalLargeScale * 1.05f, Color.black);
+			Draw.Ellipse(centre, finalLargeScale, new(0.25f, 0.25f, 0.25f));
+			Draw.Ellipse(centre, finalSmallScale, new(0.1f, 0.1f, 0.1f));
+			return Bounds2D.CreateFromCentreAndSize(centre, Vector2.one * scale);
+		}
 
 		public static Bounds2D DrawDisplay_RGB(Vector2 centre, float scale, SimChip simSource)
 		{

--- a/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
+++ b/Assets/Scripts/Graphics/World/DevSceneDrawer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DLS.Description;
 using DLS.Game;
 using DLS.Simulation;
@@ -370,15 +371,19 @@ namespace DLS.Graphics
 		{
 			Color borderCol = GetChipDisplayBorderCol(rootChip.Description.Colour);
 
+			if (display.DisplayType == ChipType.Buzzer || display.ChildDisplays.Any(child => child.DisplayType == ChipType.Buzzer))
+			{
+				return DrawDisplay(display, pos, 1, rootChip, sim);
+			}
+
 			Draw.ID displayBorderID = Draw.ReserveQuad();
 			Draw.ID displayBackingID = Draw.ReserveQuad();
 
 
 			Bounds2D bounds = DrawDisplay(display, pos, 1, rootChip, sim);
 
-			// Border colour around display
+			// Border colour and black background behind display to fill any gaps
 			Draw.ModifyQuad(displayBorderID, bounds.Centre, bounds.Size + Vector2.one * 0.03f, borderCol);
-			// Black background behind display to fill any gaps
 			Draw.ModifyQuad(displayBackingID, bounds.Centre, bounds.Size, Color.black);
 
 			return bounds;
@@ -442,7 +447,7 @@ namespace DLS.Graphics
 			}
 			else if (display.DisplayType == ChipType.Buzzer)
 			{
-				bounds = DrawBuzzer(posWorld, scaleWorld, sim);
+				bounds = DrawBuzzer(posWorld, scaleWorld, rootChip.Description.Colour, sim);
 			}
 
 			display.LastDrawBounds = bounds;
@@ -452,37 +457,37 @@ namespace DLS.Graphics
 
 		public static Vector2 CalculateChipNameBounds(string name) => Draw.CalculateTextBoundsSize(name, FontSizeChipName, FontBold, ChipNameLineSpacing);
 
-		public static Bounds2D DrawBuzzer(Vector2 centre, float scale, SimChip simSource)
+		public static Bounds2D DrawBuzzer(Vector2 centre, float scale, Color colour, SimChip simSource)
 		{
-			if (simSource == null)
+			uint frequency = 0;
+			uint amplitude = 0;
+
+			if (simSource != null)
 			{
-				return Bounds2D.CreateFromCentreAndSize(centre, Vector2.one * scale);
+				frequency = simSource.InputPins[0].State;
+				amplitude = simSource.InputPins[1].State;
 			}
 
-			// Draw background
-			Draw.Quad(centre, 1.5f * scale * Vector2.one, new(0.1f, 0.1f, 0.1f));
-
-			uint frequency = simSource.InputPins[0].State;
-			uint amplitude = simSource.InputPins[1].State;
+			bool disconnectedOrMuted = simSource == null || amplitude == 0 || amplitude >= 16 || frequency >= 256;
 
 			float remappedAmplitude = Mathf.Lerp(0.25f, 1f, Mathf.InverseLerp(2.5f, 20, amplitude));
 
 			float oscillation = Mathf.Sin(Time.time * frequency);
 
 			float minLargeScale = 0.45f * scale;
-			float maxLargeScale = amplitude == 0 ? minLargeScale : Mathf.Lerp(minLargeScale, 0.5f, remappedAmplitude);
+			float maxLargeScale = disconnectedOrMuted ? minLargeScale : Mathf.Lerp(minLargeScale, 0.5f, remappedAmplitude);
 			float remappedLargeScale = Mathf.Lerp(minLargeScale, maxLargeScale, Mathf.InverseLerp(-1f, 1f, oscillation));
 
 			float minSmallScale = 0.075f * scale;
-			float maxSmallScale = amplitude == 0 ? minSmallScale : Mathf.Lerp(minSmallScale, 0.1f, remappedAmplitude);
+			float maxSmallScale = disconnectedOrMuted ? minSmallScale : Mathf.Lerp(minSmallScale, 0.1f, remappedAmplitude);
 			float remappedSmallScale = Mathf.Lerp(minSmallScale, maxSmallScale, Mathf.InverseLerp(1f, -1f, oscillation));
 
 			Vector2 finalLargeScale = remappedLargeScale * Vector2.one;
 			Vector2 finalSmallScale = remappedSmallScale * Vector2.one;
 
-			Draw.Ellipse(centre, finalLargeScale * 1.05f, Color.black);
-			Draw.Ellipse(centre, finalLargeScale, new(0.25f, 0.25f, 0.25f));
-			Draw.Ellipse(centre, finalSmallScale, new(0.1f, 0.1f, 0.1f));
+			Draw.Ellipse(centre, finalLargeScale * 1.05f, GetChipOutlineCol(colour));
+			Draw.Ellipse(centre, finalLargeScale, ColHelper.Brighten(colour, 0.1f));
+			Draw.Ellipse(centre, finalSmallScale, colour);
 			return Bounds2D.CreateFromCentreAndSize(centre, Vector2.one * scale);
 		}
 


### PR DESCRIPTION
Hi, me again.

Felt like the buzzer could do with a glow-up, as it has no visual feedback when beeping and booping.

So I gave it a display that oscillates with the frequency and amplitude of the input:
![image](https://cdn.squiggles.dev/screenshots/Unity_TCPCX0bTAM.gif)

Always nice to have more visuals to look at in my opinion.
They are currently a bit buggy when used as displays in other chips, I'll work on that tomorrow.