### PR TITLE
Potential fix for busses being misaligned when flipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,4 +71,3 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 /.idea
 /.vsconfig
-/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 /.idea
 /.vsconfig
+/.vscode

--- a/Assets/Scripts/Game/Elements/SubChipInstance.cs
+++ b/Assets/Scripts/Game/Elements/SubChipInstance.cs
@@ -111,7 +111,8 @@ namespace DLS.Game
 		public Vector2 SnapPoint
 		{
 			get
-			{
+			{	
+				if (IsBus) return Position; // Snap bus chips to their centre to avoid misalignment when flipping
 				if (InputPins.Length != 0) return InputPins[0].GetWorldPos();
 				if (OutputPins.Length != 0) return OutputPins[0].GetWorldPos();
 				return Position;


### PR DESCRIPTION
Busses snap to their center point instead of the pin.
This avoids the issue where the start and terminator of a bus is misaligned when either is flipped as mentioned in #328 and #492
I believe this change will also come in handy if a feature is implemented to rotate busses.