### PR TITLE
Significantly improved performance by adding caching of combinational chips

### DIFF
--- a/Assets/Scripts/Description/Types/ChipDescription.cs
+++ b/Assets/Scripts/Description/Types/ChipDescription.cs
@@ -14,6 +14,7 @@ namespace DLS.Description
 		public string Name;
 		public NameDisplayLocation NameLocation;
 		public ChipType ChipType;
+		public bool ShouldBeCached;
 		public Vector2 Size;
 		public Color Colour;
 		public PinDescription[] InputPins;

--- a/Assets/Scripts/Game/Project/DevChipInstance.cs
+++ b/Assets/Scripts/Game/Project/DevChipInstance.cs
@@ -228,7 +228,7 @@ namespace DLS.Game
 			AddElement(pin);
 			if (!isLoadingFromFile)
 			{
-				Simulator.AddPin(SimChip, pin.ID, pin.IsInputPin);
+				Simulator.AddPin(SimChip, pin.ID, pin.IsInputPin, pin.BitCount);
 			}
 		}
 

--- a/Assets/Scripts/Game/Project/DevChipInstance.cs
+++ b/Assets/Scripts/Game/Project/DevChipInstance.cs
@@ -212,6 +212,9 @@ namespace DLS.Game
 			LastSavedDescription = savedDescription;
 
 			RegenerateParentChipNamesHash();
+
+			Simulator.combinationalChipCaches.Remove(savedDescription.Name);
+			Simulator.chipsKnowToNotBeCombinational.Remove(savedDescription.Name);
 		}
 
 		public void AddNewSubChip(SubChipInstance subChip, bool isLoading)

--- a/Assets/Scripts/Game/Project/Project.cs
+++ b/Assets/Scripts/Game/Project/Project.cs
@@ -122,6 +122,9 @@ namespace DLS.Game
 		{
 			if (chipLibrary.TryGetChipDescription(subchip.Description.Name, out ChipDescription description))
 			{
+				Simulator.useCaching = false; // Disable caching while viewing so subchips actually show what they are doing
+				Simulator.isCreatingACache = false; // Cancel any cache creation that might be going on
+
 				SimChip simChipToView = ViewedChip.SimChip.GetSubChipFromID(subchip.ID);
 
 				DevChipInstance viewChip = DevChipInstance.LoadFromDescriptionTest(description, chipLibrary).devChip;
@@ -140,6 +143,8 @@ namespace DLS.Game
 				chipViewStack.Pop();
 				controller.CancelEverything();
 				UpdateViewedChipsString();
+
+				if (chipViewStack.Count == 1) Simulator.useCaching = true; // Left View mode, so turn caching back on
 			}
 		}
 

--- a/Assets/Scripts/Graphics/UI/Menus/BottomBarUI.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/BottomBarUI.cs
@@ -13,7 +13,7 @@ namespace DLS.Graphics
 	{
 		public const float barHeight = 3;
 		const float padY = 0.3f;
-		const float buttonSpacing = 0.25f;
+		public const float buttonSpacing = 0.25f;
 		const float buttonHeight = barHeight - padY * 2;
 
 		const string shortcutTextCol = "<color=#666666ff>";

--- a/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/ChipCustomizationMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DLS.Description;
 using DLS.Game;
+using DLS.Simulation;
 using Seb.Helpers;
 using Seb.Vis;
 using Seb.Vis.UI;
@@ -19,6 +20,7 @@ namespace DLS.Graphics
 			"Name: Hidden"
 		};
 
+		static readonly string[] cachingOptions = { "Caching: Off", "Caching: On" };
 
 		// ---- State ----
 		static SubChipInstance[] subChipsWithDisplays;
@@ -29,6 +31,7 @@ namespace DLS.Graphics
 		static readonly UIHandle ID_ColourPicker = new("CustomizeMenu_ChipCol");
 		static readonly UIHandle ID_ColourHexInput = new("CustomizeMenu_ChipColHexInput");
 		static readonly UIHandle ID_NameDisplayOptions = new("CustomizeMenu_NameDisplayOptions");
+		static readonly UIHandle ID_CachingOptions = new("CustomizeMenu_CachingOptions");
 		static readonly UI.ScrollViewDrawElementFunc drawDisplayScrollEntry = DrawDisplayScroll;
 		static readonly Func<string, bool> hexStringInputValidator = ValidateHexStringInput;
 
@@ -76,6 +79,40 @@ namespace DLS.Graphics
 			else if (colHexCodeString != hexColInput.text)
 			{
 				UpdateChipColFromHexString(hexColInput.text);
+			}
+
+			// ---- Chip caching UI ----
+			UI.DrawText("Chip Caching:", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeDefault, NextPos(1), Anchor.TopLeft, Color.white);
+			SimChip chip = Project.ActiveProject.ViewedChip.SimChip;
+			if (chip.IsCombinational())
+			{
+				int numberOfInputBits = chip.CalculateNumberOfInputBits();
+				if (numberOfInputBits <= Simulator.MAX_NUM_INPUT_BITS_WHEN_AUTO_CACHING)
+				{
+					UI.DrawText("This chip is being cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+				}
+				else if (numberOfInputBits <= Simulator.MAX_NUM_INPUT_BITS_WHEN_USER_CACHING)
+				{
+					int shouldBeCachedNum = UI.WheelSelector(ID_CachingOptions, cachingOptions, NextPos(), new Vector2(pw, DrawSettings.ButtonHeight), theme.OptionsWheel, Anchor.TopLeft);
+					bool shouldBeCached = false;
+					if (shouldBeCachedNum == 1) shouldBeCached = true;
+					ChipSaveMenu.ActiveCustomizeDescription.ShouldBeCached = shouldBeCached;
+					UI.DrawText("WARNING: Caching chips with many", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("input bits significantly", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("increases the time required to", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("create the cache and may also", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("increase memory consumption!", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+				}
+				else
+				{
+					UI.DrawText("This chip has too many input", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+					UI.DrawText("bits to be cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+				}
+			}
+			else
+			{
+				UI.DrawText("Non-combinational chips", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
+				UI.DrawText("can not be cached.", UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeSmall, NextPos(), Anchor.TopLeft, Color.white);
 			}
 
 			// ---- Displays UI ----
@@ -151,6 +188,13 @@ namespace DLS.Graphics
 			// Init name display mode
 			WheelSelectorState nameDisplayWheelState = UI.GetWheelSelectorState(ID_NameDisplayOptions);
 			nameDisplayWheelState.index = (int)ChipSaveMenu.ActiveCustomizeDescription.NameLocation;
+
+			// Init cache setting
+			WheelSelectorState cacheSettingWheelState = UI.GetWheelSelectorState(ID_CachingOptions);
+			bool cacheBool = ChipSaveMenu.ActiveCustomizeDescription.ShouldBeCached;
+			int cacheInt = 0;
+			if (cacheBool) cacheInt = 1;
+			cacheSettingWheelState.index = cacheInt;
 		}
 
 		static void UpdateCustomizeDescription()

--- a/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs
+++ b/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs
@@ -1,0 +1,20 @@
+﻿using DLS.Simulation;
+using Seb.Helpers;
+using Seb.Vis;
+using Seb.Vis.UI;
+using UnityEngine;
+
+namespace DLS.Graphics
+{
+	public static class CreateCacheUI
+	{
+		public static void DrawCreatingCacheInfo()
+		{
+			string chipName = Simulator.nameOfChipWhoseCacheIsBeingCreated;
+			int percentage = (int)(Simulator.cacheCreatingProgress * 100);
+			string text = $"Creating Cache ({percentage}%): {chipName}";
+			Vector2 textSize = UI.CalculateTextSize(text, UIThemeLibrary.FontSizeDefault, UIThemeLibrary.DefaultFont);
+			UI.TextWithBackground(new Vector2(BottomBarUI.buttonSpacing, BottomBarUI.barHeight + BottomBarUI.buttonSpacing), new Vector2(textSize.x + 1, textSize.y + 1), Anchor.BottomLeft, text, UIThemeLibrary.DefaultFont, UIThemeLibrary.FontSizeDefault, Color.yellow, ColHelper.MakeCol255(40));
+		}
+	}
+}

--- a/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs.meta
+++ b/Assets/Scripts/Graphics/UI/Menus/CreateCacheUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f1b8d5b37edf744dbb027b01aaba678

--- a/Assets/Scripts/Graphics/UI/UIDrawer.cs
+++ b/Assets/Scripts/Graphics/UI/UIDrawer.cs
@@ -1,4 +1,5 @@
 using DLS.Game;
+using DLS.Simulation;
 using Seb.Vis.UI;
 
 namespace DLS.Graphics
@@ -73,6 +74,7 @@ namespace DLS.Graphics
 				bool showSimPausedBanner = project.simPaused;
 				if (showSimPausedBanner) SimPausedUI.DrawPausedBanner();
 				if (project.chipViewStack.Count > 1) ViewedChipsBar.DrawViewedChipsBanner(project, showSimPausedBanner);
+				if (Simulator.isCreatingACache) CreateCacheUI.DrawCreatingCacheInfo();
 			}
 
 			ContextMenu.Update();

--- a/Assets/Scripts/Graphics/UI/UIDrawer.cs
+++ b/Assets/Scripts/Graphics/UI/UIDrawer.cs
@@ -58,6 +58,7 @@ namespace DLS.Graphics
 
 			if (menuToDraw != MenuType.ChipCustomization) BottomBarUI.DrawUI(project);
 
+			bool aMenuIsOpen = true;
 			if (menuToDraw == MenuType.ChipSave) ChipSaveMenu.DrawMenu();
 			else if (menuToDraw == MenuType.ChipLibrary) ChipLibraryMenu.DrawMenu();
 			else if (menuToDraw == MenuType.ChipCustomization) ChipCustomizationMenu.DrawMenu();
@@ -75,7 +76,10 @@ namespace DLS.Graphics
 				if (showSimPausedBanner) SimPausedUI.DrawPausedBanner();
 				if (project.chipViewStack.Count > 1) ViewedChipsBar.DrawViewedChipsBanner(project, showSimPausedBanner);
 				if (Simulator.isCreatingACache) CreateCacheUI.DrawCreatingCacheInfo();
+				aMenuIsOpen = false;
 			}
+
+			if (aMenuIsOpen) Simulator.isCreatingACache = false; // Cancel current caching process when a menu gets opened
 
 			ContextMenu.Update();
 		}

--- a/Assets/Scripts/SaveSystem/DescriptionCreator.cs
+++ b/Assets/Scripts/SaveSystem/DescriptionCreator.cs
@@ -37,6 +37,7 @@ namespace DLS.SaveSystem
 				NameLocation = hasSavedDesc ? descOld.NameLocation : NameDisplayLocation.Centre,
 				Size = size,
 				Colour = col,
+				ShouldBeCached = hasSavedDesc ? descOld.ShouldBeCached : false,
 
 				SubChips = subchips,
 				InputPins = inputPins,

--- a/Assets/Scripts/SaveSystem/Loader.cs
+++ b/Assets/Scripts/SaveSystem/Loader.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DLS.Description;
 using DLS.Game;
+using DLS.Simulation;
 
 namespace DLS.SaveSystem
 {
@@ -24,6 +25,10 @@ namespace DLS.SaveSystem
 		{
 			ProjectDescription projectDescription = LoadProjectDescription(projectName);
 			ChipLibrary chipLibrary = LoadChipLibrary(projectDescription);
+
+			Simulator.combinationalChipCaches.Clear();
+			Simulator.chipsKnowToNotBeCombinational.Clear();
+
 			return new Project(projectDescription, chipLibrary);
 		}
 

--- a/Assets/Scripts/Simulation/SimChip.cs
+++ b/Assets/Scripts/Simulation/SimChip.cs
@@ -18,7 +18,6 @@ namespace DLS.Simulation
 		public SimPin[] InputPins = Array.Empty<SimPin>();
 		public int numConnectedInputs;
 		public bool shouldBeCached; // True, if the user specifically wanted this chip to be cached
-		public bool isCached; // True for cached chips, whose outputs get determined by a LUT
 
 		public int numInputsReady;
 		public SimPin[] OutputPins = Array.Empty<SimPin>();

--- a/Assets/Scripts/Simulation/SimChip.cs
+++ b/Assets/Scripts/Simulation/SimChip.cs
@@ -36,6 +36,7 @@ namespace DLS.Simulation
 			ID = id;
 			Name = desc.Name;
 			ChipType = desc.ChipType;
+			shouldBeCached = desc.ShouldBeCached;
 			IsBuiltin = ChipType != ChipType.Custom;
 
 			// ---- Create pins (don't allocate unnecessarily as very many sim chips maybe created!) ----

--- a/Assets/Scripts/Simulation/SimPin.cs
+++ b/Assets/Scripts/Simulation/SimPin.cs
@@ -1,3 +1,4 @@
+using DLS.Description;
 using System;
 
 namespace DLS.Simulation
@@ -7,6 +8,7 @@ namespace DLS.Simulation
 		public readonly int ID;
 		public readonly SimChip parentChip;
 		public readonly bool isInput;
+		public readonly PinBitCount numberOfBits;
 		public uint State;
 
 		public SimPin[] ConnectedTargetPins = Array.Empty<SimPin>();
@@ -23,10 +25,11 @@ namespace DLS.Simulation
 		public int numInputConnections;
 		public int numInputsReceivedThisFrame;
 
-		public SimPin(int id, bool isInput, SimChip parentChip)
+		public SimPin(int id, bool isInput, PinBitCount numberOfBits, SimChip parentChip)
 		{
 			this.parentChip = parentChip;
 			this.isInput = isInput;
+			this.numberOfBits = numberOfBits;
 			ID = id;
 			latestSourceID = -1;
 			latestSourceParentChipID = -1;

--- a/Assets/Scripts/Simulation/Simulator.cs
+++ b/Assets/Scripts/Simulation/Simulator.cs
@@ -20,6 +20,11 @@ namespace DLS.Simulation
 		public static readonly Dictionary<string, uint[][]> combinationalChipCaches = new();
 		public static readonly HashSet<string> chipsKnowToNotBeCombinational = new();
 
+		// Variables for the creating cache info popup
+		public static bool isCreatingACache = false;
+		public static string nameOfChipWhoseCacheIsBeingCreated;
+		public static float cacheCreatingProgress;
+
 		public static readonly Random rng = new();
 		static readonly Stopwatch stopwatch = Stopwatch.StartNew();
 		public static int stepsPerClockTransition;
@@ -229,6 +234,10 @@ namespace DLS.Simulation
 					continue;
 				}
 
+				nameOfChipWhoseCacheIsBeingCreated = subChip.Name;
+				cacheCreatingProgress = 0;
+				isCreatingACache = true;
+
 				// Buffer current Input
 				uint[] bufferedInput = new uint[subChip.InputPins.Length];
 				for (int i = 0; i < bufferedInput.Length; i++)
@@ -260,6 +269,8 @@ namespace DLS.Simulation
 						outputs[i] = subChip.OutputPins[i].State;
 					}
 					LUT[input] = outputs;
+
+					cacheCreatingProgress = (float)input / numberOfPossibleInputs;
 				}
 				combinationalChipCaches[subChip.Name] = LUT;
 
@@ -272,6 +283,8 @@ namespace DLS.Simulation
 				StepChip(subChip); // make sure the outputs are also correct again
 
 				subChip.isCached = true;
+
+				isCreatingACache = false;
 			}
 		}
 		

--- a/Assets/Scripts/Simulation/Simulator.cs
+++ b/Assets/Scripts/Simulation/Simulator.cs
@@ -19,6 +19,7 @@ namespace DLS.Simulation
 		// Small, purely combinational chips use a LUT for fast calculations. These are stored here. Maps the name of a chip to its LUT.
 		public static readonly Dictionary<string, uint[][]> combinationalChipCaches = new();
 		public static readonly HashSet<string> chipsKnowToNotBeCombinational = new();
+		public static bool useCaching = true;
 
 		// Variables for the creating cache info popup
 		public static bool isCreatingACache = false;
@@ -153,12 +154,12 @@ namespace DLS.Simulation
 				{
 					ProcessBuiltinChip(nextSubChip); // We've reached a built-in chip, so process it directly
 				}
-				else if (combinationalChipCaches.ContainsKey(nextSubChip.Name))
+				else if (combinationalChipCaches.ContainsKey(nextSubChip.Name) && useCaching)
 				{
 					bool wasSuccessful = ProcessCachedChip(nextSubChip); // We found a cached chip, so use LUT to process it directly
 					if (!wasSuccessful) StepChip(nextSubChip); // Fallback to normal simulation, if lookup failed
 				}
-				else if (!chipsKnowToNotBeCombinational.Contains(nextSubChip.Name))
+				else if (!chipsKnowToNotBeCombinational.Contains(nextSubChip.Name) && useCaching)
 				{
 					RecalculateCachedLUTs(nextSubChip); // We found a chip that isn't cached but might be cachable, so we try to cache it
 					StepChip(nextSubChip);


### PR DESCRIPTION
Purely combinational chips, so chips whose outputs entirely depend on their inputs and on nothing else, who also don't have too many input bits, now get cached. This means that a look up table (LUT) with 2^(number of input bits) entries gets created and whenever this chip needs to determine its output, it can just use the LUT to immediately know what its output should be.

This usually gave me a speedup of up to 4x (for example my CPU  went from 1500 sps to more than 5000 sps).

Also added some UI in the chip customization menu where the player can decide for medium sized chips whether they should get cached or not.
Also added a little pop up info to give progress information when creating large caches.

Any special cases (like displays, keys, tristated values, view mode, ...) also all get handled correctly (usually by turning off chip caching).