### PR TITLE
feat(io-pins): add 16-bit input and output pin blocks

### DIFF
--- a/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
+++ b/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
@@ -20,9 +20,13 @@ namespace DLS.Description
 			// ---- Split / Merge ----
 			{ ChipType.Split_4To1Bit, "4-1BIT" },
 			{ ChipType.Split_8To1Bit, "8-1BIT" },
+			{ ChipType.Split_16To1Bit, "16-1BIT" },
 			{ ChipType.Split_8To4Bit, "8-4BIT" },
+			{ ChipType.Split_16To8Bit, "16-8BIT" },
 			{ ChipType.Merge_4To8Bit, "4-8BIT" },
+			{ ChipType.Merge_8To16Bit, "8-16BIT" },
 			{ ChipType.Merge_1To8Bit, "1-8BIT" },
+			{ ChipType.Merge_1To16Bit, "1-16BIT" },
 			{ ChipType.Merge_1To4Bit, "1-4BIT" },
 
 			// ---- Displays -----

--- a/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
+++ b/Assets/Scripts/Description/Helpers/ChipTypeHelper.cs
@@ -39,9 +39,11 @@ namespace DLS.Description
 			{ ChipType.In_1Bit, "IN-1" },
 			{ ChipType.In_4Bit, "IN-4" },
 			{ ChipType.In_8Bit, "IN-8" },
+			{ ChipType.In_16Bit, "IN-16" },
 			{ ChipType.Out_1Bit, "OUT-1" },
 			{ ChipType.Out_4Bit, "OUT-4" },
 			{ ChipType.Out_8Bit, "OUT-8" },
+			{ ChipType.Out_16Bit, "OUT-16" },
 			{ ChipType.Key, "KEY" },
 			// ---- Buses ----
 			{ ChipType.Bus_1Bit, "BUS-1" },
@@ -82,6 +84,7 @@ namespace DLS.Description
 					PinBitCount.Bit1 => ChipType.In_1Bit,
 					PinBitCount.Bit4 => ChipType.In_4Bit,
 					PinBitCount.Bit8 => ChipType.In_8Bit,
+					PinBitCount.Bit16 => ChipType.In_16Bit,
 					_ => throw new Exception("No input pin type found for bitcount: " + numBits)
 				};
 			}
@@ -91,6 +94,7 @@ namespace DLS.Description
 				PinBitCount.Bit1 => ChipType.Out_1Bit,
 				PinBitCount.Bit4 => ChipType.Out_4Bit,
 				PinBitCount.Bit8 => ChipType.Out_8Bit,
+				PinBitCount.Bit16 => ChipType.Out_16Bit,
 				_ => throw new Exception("No output pin type found for bitcount: " + numBits)
 			};
 		}
@@ -105,6 +109,8 @@ namespace DLS.Description
 				ChipType.Out_4Bit => (false, true, PinBitCount.Bit4),
 				ChipType.In_8Bit => (true, false, PinBitCount.Bit8),
 				ChipType.Out_8Bit => (false, true, PinBitCount.Bit8),
+				ChipType.In_16Bit => (true, false, PinBitCount.Bit16),
+				ChipType.Out_16Bit => (false, true, PinBitCount.Bit16),
 				_ => (false, false, PinBitCount.Bit1)
 			};
 		}

--- a/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
+++ b/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
@@ -23,10 +23,14 @@ namespace DLS.Description
 		// ---- Merge / Split ----
 		Merge_1To4Bit,
 		Merge_1To8Bit,
+		Merge_1To16Bit,
 		Merge_4To8Bit,
+		Merge_8To16Bit,
 		Split_4To1Bit,
 		Split_8To4Bit,
 		Split_8To1Bit,
+		Split_16To8Bit,
+		Split_16To1Bit,
 
 		// ---- In / Out Pins ----
 		In_1Bit,

--- a/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
+++ b/Assets/Scripts/Description/Types/SubTypes/ChipTypes.cs
@@ -32,9 +32,11 @@ namespace DLS.Description
 		In_1Bit,
 		In_4Bit,
 		In_8Bit,
+		In_16Bit,
 		Out_1Bit,
 		Out_4Bit,
 		Out_8Bit,
+		Out_16Bit,
 
 		Key,
 

--- a/Assets/Scripts/Description/Types/SubTypes/PinDescription.cs
+++ b/Assets/Scripts/Description/Types/SubTypes/PinDescription.cs
@@ -26,7 +26,8 @@ namespace DLS.Description
 	{
 		Bit1 = 1,
 		Bit4 = 4,
-		Bit8 = 8
+		Bit8 = 8,
+		Bit16 = 16
 	}
 
 	public enum PinColour

--- a/Assets/Scripts/Game/Elements/DevPinInstance.cs
+++ b/Assets/Scripts/Game/Elements/DevPinInstance.cs
@@ -42,6 +42,7 @@ namespace DLS.Game
 				PinBitCount.Bit1 => new Vector2Int(1, 1),
 				PinBitCount.Bit4 => new Vector2Int(2, 2),
 				PinBitCount.Bit8 => new Vector2Int(4, 2),
+				PinBitCount.Bit16 => new Vector2Int(8, 2),
 				_ => throw new Exception("Bit count not implemented")
 			};
 			StateGridSize = BitCount switch

--- a/Assets/Scripts/Game/Elements/DevPinInstance.cs
+++ b/Assets/Scripts/Game/Elements/DevPinInstance.cs
@@ -59,7 +59,14 @@ namespace DLS.Game
 		{
 			get
 			{
-				int gridDst = BitCount is PinBitCount.Bit1 or PinBitCount.Bit4 ? 6 : 9;
+				int gridDst = BitCount switch
+			{
+				PinBitCount.Bit1 => 6,
+				PinBitCount.Bit4 => 6,
+				PinBitCount.Bit8 => 9,
+				PinBitCount.Bit16 => 13, // Wider grid needs more distance
+				_ => 9
+			};
 				return HandlePosition + faceDir * (GridSize * gridDst);
 			}
 		}

--- a/Assets/Scripts/Game/Elements/SubChipInstance.cs
+++ b/Assets/Scripts/Game/Elements/SubChipInstance.cs
@@ -309,6 +309,7 @@ namespace DLS.Game
 				PinBitCount.Bit1 => DrawSettings.PinRadius * 2,
 				PinBitCount.Bit4 => DrawSettings.PinHeight4Bit,
 				PinBitCount.Bit8 => DrawSettings.PinHeight8Bit,
+				PinBitCount.Bit16 => DrawSettings.PinHeight16Bit,
 				_ => throw new Exception("Bit count not implemented " + bitCount)
 			};
 		}

--- a/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
@@ -36,10 +36,14 @@ namespace DLS.Game
 				CreateBitConversionChip(ChipType.Split_4To1Bit, PinBitCount.Bit4, PinBitCount.Bit1, 1, 4),
 				CreateBitConversionChip(ChipType.Split_8To4Bit, PinBitCount.Bit8, PinBitCount.Bit4, 1, 2),
 				CreateBitConversionChip(ChipType.Split_8To1Bit, PinBitCount.Bit8, PinBitCount.Bit1, 1, 8),
+				CreateBitConversionChip(ChipType.Split_16To8Bit, PinBitCount.Bit16, PinBitCount.Bit8, 1, 2),
+				CreateBitConversionChip(ChipType.Split_16To1Bit, PinBitCount.Bit16, PinBitCount.Bit1, 1, 16),
 
 				CreateBitConversionChip(ChipType.Merge_1To8Bit, PinBitCount.Bit1, PinBitCount.Bit8, 8, 1),
+				CreateBitConversionChip(ChipType.Merge_1To16Bit, PinBitCount.Bit1, PinBitCount.Bit16, 16, 1),
 				CreateBitConversionChip(ChipType.Merge_1To4Bit, PinBitCount.Bit1, PinBitCount.Bit4, 4, 1),
 				CreateBitConversionChip(ChipType.Merge_4To8Bit, PinBitCount.Bit4, PinBitCount.Bit8, 2, 1),
+				CreateBitConversionChip(ChipType.Merge_8To16Bit, PinBitCount.Bit8, PinBitCount.Bit16, 2, 1),
 				// ---- Displays ----
 				CreateDisplay7Seg(),
 				CreateDisplayRGB(),

--- a/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinChipCreator.cs
@@ -21,6 +21,8 @@ namespace DLS.Game
 				CreateInputOrOutputPin(ChipType.Out_4Bit),
 				CreateInputOrOutputPin(ChipType.In_8Bit),
 				CreateInputOrOutputPin(ChipType.Out_8Bit),
+				CreateInputOrOutputPin(ChipType.In_16Bit),
+				CreateInputOrOutputPin(ChipType.Out_16Bit),
 				CreateInputKeyChip(),
 				// ---- Basic Chips ----
 				CreateNand(),

--- a/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
@@ -38,10 +38,14 @@ namespace DLS.Game
 				CreateChipCollection("MERGE/SPLIT",
 					ChipType.Merge_1To4Bit,
 					ChipType.Merge_1To8Bit,
+					ChipType.Merge_1To16Bit,
 					ChipType.Merge_4To8Bit,
+					ChipType.Merge_8To16Bit,
 					ChipType.Split_4To1Bit,
 					ChipType.Split_8To4Bit,
-					ChipType.Split_8To1Bit
+					ChipType.Split_8To1Bit,
+					ChipType.Split_16To8Bit,
+					ChipType.Split_16To1Bit
 				),
 				CreateChipCollection("BUS",
 					ChipType.Bus_1Bit,

--- a/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
+++ b/Assets/Scripts/Game/Project/BuiltinCollectionCreator.cs
@@ -29,9 +29,11 @@ namespace DLS.Game
 					ChipType.In_1Bit,
 					ChipType.In_4Bit,
 					ChipType.In_8Bit,
+					ChipType.In_16Bit,
 					ChipType.Out_1Bit,
 					ChipType.Out_4Bit,
-					ChipType.Out_8Bit
+					ChipType.Out_8Bit,
+					ChipType.Out_16Bit
 				),
 				CreateChipCollection("MERGE/SPLIT",
 					ChipType.Merge_1To4Bit,

--- a/Assets/Scripts/Graphics/DrawSettings.cs
+++ b/Assets/Scripts/Graphics/DrawSettings.cs
@@ -13,6 +13,7 @@ namespace DLS.Graphics
 		public const float PinHeight1Bit = 0.185f;
 		public const float PinHeight4Bit = 0.3f;
 		public const float PinHeight8Bit = 0.43f;
+		public const float PinHeight16Bit = 0.43f; // Same visual height as 8-bit; bits shown in 8x2 grid
 		public const float PinRadius = PinHeight1Bit / 2;
 
 		public const FontType FontBold = FontType.JetbrainsMonoBold;

--- a/Assets/Scripts/Simulation/Simulator.cs
+++ b/Assets/Scripts/Simulation/Simulator.cs
@@ -337,6 +337,52 @@ namespace DLS.Simulation
 					chip.OutputPins[7].State = (in8 >> 0) & PinState.SingleBitMask;
 					break;
 				}
+				case ChipType.Split_16To8Bit:
+				{
+					uint in16 = chip.InputPins[0].State;
+					// Split into two 8-bit values: high byte and low byte
+					ushort lowByte = (ushort)(in16 & 0xFF);
+					ushort highByte = (ushort)((in16 >> 8) & 0xFF);
+					ushort tristateFlags = (ushort)(in16 >> 16);
+					ushort lowTristate = (ushort)(tristateFlags & 0xFF);
+					ushort highTristate = (ushort)((tristateFlags >> 8) & 0xFF);
+					
+					chip.OutputPins[0].State = (uint)(highByte | (highTristate << 16)); // MSB
+					chip.OutputPins[1].State = (uint)(lowByte | (lowTristate << 16));   // LSB
+					break;
+				}
+				case ChipType.Split_16To1Bit:
+				{
+					uint in16 = chip.InputPins[0].State;
+					for (int i = 0; i < 16; i++)
+					{
+						chip.OutputPins[i].State = (in16 >> (15 - i)) & PinState.SingleBitMask;
+					}
+					break;
+				}
+				case ChipType.Merge_8To16Bit:
+				{
+					uint in8High = chip.InputPins[0].State; // MSB
+					uint in8Low = chip.InputPins[1].State;  // LSB
+					ushort highByte = (ushort)(in8High & 0xFF);
+					ushort lowByte = (ushort)(in8Low & 0xFF);
+					ushort highTristate = (ushort)((in8High >> 16) & 0xFF);
+					ushort lowTristate = (ushort)((in8Low >> 16) & 0xFF);
+					
+					chip.OutputPins[0].State = (uint)(lowByte | (highByte << 8) | (lowTristate << 16) | (highTristate << 24));
+					break;
+				}
+				case ChipType.Merge_1To16Bit:
+				{
+					uint result = 0;
+					for (int i = 0; i < 16; i++)
+					{
+						uint bitState = chip.InputPins[15 - i].State & PinState.SingleBitMask;
+						result |= bitState << i;
+					}
+					chip.OutputPins[0].State = result;
+					break;
+				}
 				case ChipType.TriStateBuffer:
 				{
 					SimPin dataPin = chip.InputPins[0];


### PR DESCRIPTION
- Add Bit16 = 16 to PinBitCount enum
- Add In_16Bit and Out_16Bit to ChipType enum
- Register IN-16 and OUT-16 names in ChipTypeHelper.Names
- Update GetPinType() and IsInputOrOutputPin() switch statements for Bit16
- Register CreateInputOrOutputPin() calls in BuiltinChipCreator
- Add In_16Bit / Out_16Bit to the IN/OUT chip collection in BuiltinCollectionCreator
- Add StateGridDimensions case (8x2) for Bit16 in DevPinInstance
- Add PinHeight16Bit constant to DrawSettings (same height as Bit8, 8x2 grid)
- Add Bit16 case to PinHeightFromBitCount in SubChipInstance

The simulation layer already natively supports 16 data bits via its uint32 state format (upper 16 bits = tristate flags, lower 16 bits = data). Wire rendering and multi-bit dev pin drawing are already data-driven and require no changes.